### PR TITLE
Scale Gizmo Dimensions individually to prevent weird morphing

### DIFF
--- a/Editor/Gizmo.cpp
+++ b/Editor/Gizmo.cpp
@@ -56,14 +56,22 @@ namespace UltraEd
 
     void Gizmo::Render(IDirect3DDevice9 *device, ID3DXMatrixStack *stack, View *view)
     {
-        // Scale the size of the gizmo based on the view distance.
-        D3DXVECTOR3 gizmoPos = m_models[0].GetPosition();
-        D3DXVECTOR3 viewPos = m_models[0].GetPosition();
-        float distX = gizmoPos.x - viewPos.x;
-        float distY = gizmoPos.y - viewPos.y;
-        float distZ = gizmoPos.z - viewPos.z;
-        float scaleFactor = view->GetType() == ViewType::Perspective ? 0.2f : 0.1f;
-        SetScale(D3DXVECTOR3(distX * scaleFactor, distY * scaleFactor, distZ * scaleFactor));
+        // Scale the size of the gizmo based on the view.
+
+        D3DXVECTOR3 gizPos = m_models[0].GetPosition();
+        D3DXVECTOR3 viewPos = view->GetPosition();
+        D3DXVECTOR3 difference = gizPos - viewPos;
+
+        float dist = D3DXVec3Dot(&difference, &view->GetForward());
+        D3DVIEWPORT9 viewport;
+        device->GetViewport(&viewport);
+        DWORD width = viewport.Width;
+        DWORD height = viewport.Height;
+        float tan = std::tanf((D3DX_PI / 2.0f) * (180.0f / D3DX_PI));
+        float denom = std::sqrtf(width * width + height * height) * std::tanf(60.0f);
+        float scale = std::max(0.0001f, dist / denom * 100.0f);
+        SetScale(D3DXVECTOR3(scale, scale, scale));
+
 
         // Render all gizmo handles.
         device->SetMaterial(&m_redMaterial);

--- a/Editor/Gizmo.cpp
+++ b/Editor/Gizmo.cpp
@@ -68,7 +68,7 @@ namespace UltraEd
         DWORD width = viewport.Width;
         DWORD height = viewport.Height;
         float denom = std::sqrtf(width * width + height * height) * std::tanf(60.0f);
-        float scale = std::max(0.0001f, dist / denom * 100.0f);
+        float scale = dist / denom * 100.0f;
         SetScale(D3DXVECTOR3(scale, scale, scale));
 
 

--- a/Editor/Gizmo.cpp
+++ b/Editor/Gizmo.cpp
@@ -67,7 +67,6 @@ namespace UltraEd
         device->GetViewport(&viewport);
         DWORD width = viewport.Width;
         DWORD height = viewport.Height;
-        float tan = std::tanf((D3DX_PI / 2.0f) * (180.0f / D3DX_PI));
         float denom = std::sqrtf(width * width + height * height) * std::tanf(60.0f);
         float scale = std::max(0.0001f, dist / denom * 100.0f);
         SetScale(D3DXVECTOR3(scale, scale, scale));

--- a/Editor/Gizmo.cpp
+++ b/Editor/Gizmo.cpp
@@ -57,10 +57,13 @@ namespace UltraEd
     void Gizmo::Render(IDirect3DDevice9 *device, ID3DXMatrixStack *stack, View *view)
     {
         // Scale the size of the gizmo based on the view distance.
-        D3DXVECTOR3 distance = m_models[0].GetPosition() - view->GetPosition();
+        D3DXVECTOR3 gizmoPos = m_models[0].GetPosition();
+        D3DXVECTOR3 viewPos = m_models[0].GetPosition();
+        float distX = gizmoPos.x - viewPos.x;
+        float distY = gizmoPos.y - viewPos.y;
+        float distZ = gizmoPos.z - viewPos.z;
         float scaleFactor = view->GetType() == ViewType::Perspective ? 0.2f : 0.1f;
-        float length = D3DXVec3Length(&distance) * scaleFactor;
-        SetScale(D3DXVECTOR3(length, length, length));
+        SetScale(D3DXVECTOR3(distX * scaleFactor, distY * scaleFactor, distZ * scaleFactor));
 
         // Render all gizmo handles.
         device->SetMaterial(&m_redMaterial);


### PR DESCRIPTION
Scaling the Gizmos individually in each direction based on the view distance in the particular direction.
This will reduce the existing issues of weird gizmo scaling when you for example position the editor view in front of an object with active gizmos and move only to the left or right.